### PR TITLE
Fix Import Issues

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -35,6 +35,7 @@
     "babel-preset-react": "^6.0.15",
     "babel-preset-stage-0": "^6.0.15",
     "eslint-plugin-react": "^3.6.2",
+    "json-loader": "^0.5.4",
     "react-hot-loader": "^1.3.0",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.1"

--- a/examples/src/App.js
+++ b/examples/src/App.js
@@ -1,10 +1,11 @@
-import React, { Component } from 'react';
-// import SimpleFormat from 'react-simple-format'  // TODO : loads just fine as long as this is not enabled.  When enabled, the error says that it is looking for a file named src, rather than in the src directory but the webpack.config.js looks correct to me.
+import React, { Component } from 'react'
+import SimpleFormat from 'react-simple-format'
 
 export default class App extends Component {
-  render() {
+  render () {
+    const text = 'hello\n\nworld'
     return (
-      <h1>Hello, world.</h1>
-    );
+      <SimpleFormat text={ text } />
+    )
   }
 }

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -21,6 +21,12 @@ module.exports = {
       test: /\.js$/,
       loaders: ['react-hot', 'babel'],
       include: path.join(__dirname, 'src')
+    }, {
+      test: /\.js$/,
+      loaders: ['react-hot', 'babel'],
+      include: path.join(__dirname, '..', 'src')
+    }, {
+      test: /\.json$/, loader: 'json-loader'
     }]
   },
   resolve: {

--- a/package.json
+++ b/package.json
@@ -48,4 +48,7 @@
   "dependencies": {
     "sanitize-html": "^1.11.1"
   },
+  "standard": {
+    "parser": "babel-eslint"
+  }
 }


### PR DESCRIPTION
This was a nasty error and sorry I didn't catch this before. What webpack was saying (`"cannot find module 'react-simple-format'`) was apparently not the actual error. I first commented out the `import` statement, then uncommented it, and when webpack hot-reloaded the files it displayed this error:

![image](https://cloud.githubusercontent.com/assets/992008/11871755/f76e16b0-a514-11e5-9a28-08909468ef17.png)

This happened because `SimpleFormat` requires `sanitize-html`, and when importing `sanitize-html` it tries to import some JSON files as well. However, webpack doesn't know how to load JSON files by default, so we need to use `json-loader` webpack plugin.

This JSON loading problem was only an issue for the `example` code (which uses webpack for compilation, instead of straight-up `babel` used in the library code: https://github.com/rilkevb/React-SimpleFormat-Component/blob/d24170b831e8ae04adc5c051f36c420cfa21685b/package.json#L16) and that's why it was nontrivial to catch. I wish webpack reported those errors correctly instead of just saying `"cannot find module 'react-simple-format'`.